### PR TITLE
Add max sticky item and monster house chance

### DIFF
--- a/skytemple_randomizer/data/default.json
+++ b/skytemple_randomizer/data/default.json
@@ -13,6 +13,8 @@
     "pokemon": true,
     "traps": true,
     "fixed_rooms": false,
+    "max_sticky_chance": 100,
+    "max_mh_chance": 100,
     "settings": {
       "0": {"randomize": true, "unlock": true, "randomize_weather": true, "monster_houses": true, "enemy_iq": true },
       "1": {"randomize": true, "unlock": false, "randomize_weather": false, "monster_houses": false, "enemy_iq": false },

--- a/skytemple_randomizer/frontend/common_web/src/Settings.jsx
+++ b/skytemple_randomizer/frontend/common_web/src/Settings.jsx
@@ -31,6 +31,7 @@ import {
     updateGenericGridInConfig,
     updateInConfig
 } from "./config";
+import {UiSlider} from "./UiSlider";
 
 function parseHelp(txt) {
     return txt ? txt : 'No help available.';
@@ -67,6 +68,16 @@ export default function Settings(props) {
                     id={id}
                     initial={window.loadedConfig[props.for][fieldName]}
                     label={fieldConfig[0]}
+                    onChange={updateInConfig}
+                />
+                break;
+            case UiSlider:
+                field = <UiSlider
+                    id={id}
+                    initial={window.loadedConfig[props.for][fieldName]}
+                    label={fieldConfig[0]}
+                    help={parseHelp(window.HELP_TEXTS[props.for][fieldName])}
+                    max={fieldConfig[2]}
                     onChange={updateInConfig}
                 />
                 break;

--- a/skytemple_randomizer/frontend/common_web/src/UiSlider.jsx
+++ b/skytemple_randomizer/frontend/common_web/src/UiSlider.jsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+ *
+ * This file is part of SkyTemple.
+ *
+ * SkyTemple is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SkyTemple is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {useSettingsStyles} from "./theme";
+import React, {useState} from "react";
+import Paper from "@material-ui/core/Paper";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import NativeSelect from "@material-ui/core/NativeSelect";
+import {HelpButton} from "./HelpButton";
+import {Slider} from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
+
+export function UiSlider(props) {
+    const classes = useSettingsStyles();
+    const [state, setState] = useState(props.initial)
+
+    const handleChange = (event, newValue) => {
+        setState(Math.ceil(newValue));
+        props.onChange(props.id, Math.ceil(newValue));
+    };
+    return (
+        <Paper className={classes.paper}>
+            <FormControl className={classes.formControl}>
+                <Typography id={props.id + '-label'}>{props.label}</Typography>
+                <div style={{width: '500px', maxWidth: '100%'}}>
+                    <Slider
+                      defaultValue={state}
+                      step={1}
+                      min={0}
+                      max={props.max}
+                      valueLabelDisplay="auto"
+                      onChange={handleChange}
+                    />
+                </div>
+            </FormControl>
+            <HelpButton text={props.help} title={props.label}/>
+        </Paper>
+    )
+}

--- a/skytemple_randomizer/frontend/common_web/src/config.jsx
+++ b/skytemple_randomizer/frontend/common_web/src/config.jsx
@@ -23,6 +23,7 @@ import {UiGridTable} from "./UiGridTable";
 import {UiTextField} from "./UiTextField";
 import {default as set} from 'set-value';
 import {default as get} from 'get-value';
+import {UiSlider} from "./UiSlider";
 
 export const SETTINGS_CONFIG = {
     starters_npcs: {
@@ -44,6 +45,8 @@ export const SETTINGS_CONFIG = {
         pokemon: ["Randomize Pokémon Spawns?", UiSwitch],
         traps: ["Randomize Traps?", UiSwitch],
         fixed_rooms: ["Randomize Boss Room Layouts?", UiSwitch],
+        max_sticky_chance: ["Max sticky item chance", UiSlider, 100],
+        max_mh_chance: ["Max monster house chance", UiSlider, 100],
         settings: ["Dungeon Settings", UiGridTable, {
             _name: ["Dungeon", String, (id) => id.toString() + ': ' + window.DUNGEON_NAMES[id]],
             randomize: ["Randomize?", UiSwitch],

--- a/skytemple_randomizer/frontend/gtk/config.py
+++ b/skytemple_randomizer/frontend/gtk/config.py
@@ -24,7 +24,7 @@ from gi.repository import Gtk
 
 from skytemple_files.common.ppmdu_config.dungeon_data import Pmd2DungeonDungeon
 from skytemple_files.data.md.model import Ability
-from skytemple_randomizer.config import RandomizerConfig, CLASSREF, DungeonSettingsConfig
+from skytemple_randomizer.config import RandomizerConfig, CLASSREF, DungeonSettingsConfig, IntRange
 
 
 class ConfigUIApplier:
@@ -59,6 +59,10 @@ class ConfigUIApplier:
             assert field_name, "Field name must be set for primitive"
             w: Gtk.ComboBox = self._ui_get('cb_' + field_name)
             w.set_active_id(str(config))
+        elif typ == IntRange:
+            assert field_name, "Field name must be set for primitive"
+            w: Gtk.Scale = self._ui_get('scale_' + field_name)
+            w.set_value(getattr(config, 'value'))
         elif typ == str:
             assert field_name, "Field name must be set for primitive"
             try:
@@ -120,6 +124,10 @@ class ConfigUIReader:
             assert field_name, "Field name must be set for primitive"
             w: Gtk.ComboBox = self._ui_get('cb_' + field_name)
             return int(w.get_active_id())
+        elif typ == IntRange:
+            assert field_name, "Field name must be set for primitive"
+            w: Gtk.Scale = self._ui_get('scale_' + field_name)
+            return typ(int(w.get_value()))
         elif typ == str:
             assert field_name, "Field name must be set for primitive"
             try:

--- a/skytemple_randomizer/frontend/gtk/skytemple_randomizer.glade
+++ b/skytemple_randomizer/frontend/gtk/skytemple_randomizer.glade
@@ -2,6 +2,14 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAdjustment" id="adjustment_max_mh_chance">
+    <property name="upper">100</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_max_sticky_chance">
+    <property name="upper">100</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -698,10 +706,11 @@ shop and dungeon rewards?</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <child>
-                      <!-- n-columns=3 n-rows=7 -->
+                      <!-- n-columns=6 n-rows=6 -->
                       <object class="GtkGrid">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="halign">start</property>
                         <property name="margin-left">5</property>
                         <property name="margin-right">5</property>
                         <property name="margin-start">5</property>
@@ -711,6 +720,57 @@ shop and dungeon rewards?</property>
                         <property name="row-spacing">10</property>
                         <property name="column-spacing">10</property>
                         <child>
+                          <object class="GtkButton" id="help_dungeons_mode">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">4</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="cb_dungeons_mode">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="model">store_cb_dungeons_mode</property>
+                            <property name="active">0</property>
+                            <property name="id-column">0</property>
+                            <child>
+                              <object class="GtkCellRendererText"/>
+                              <attributes>
+                                <attribute name="text">1</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">5</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Mode</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">3</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -719,19 +779,7 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Randomize Weather?</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">2</property>
+                            <property name="top-attach">0</property>
                           </packing>
                         </child>
                         <child>
@@ -751,6 +799,30 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="switch_dungeons_layouts">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Randomize Weather?</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
                             <property name="top-attach">1</property>
                           </packing>
                         </child>
@@ -771,15 +843,22 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">2</property>
+                            <property name="top-attach">1</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="switch_dungeons_layouts">
+                          <object class="GtkComboBox" id="cb_dungeons_weather">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="active">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="model">store_cb_dungeons_weather</property>
+                            <property name="active">2</property>
+                            <property name="id-column">0</property>
+                            <child>
+                              <object class="GtkCellRendererText"/>
+                              <attributes>
+                                <attribute name="text">1</attribute>
+                              </attributes>
+                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">2</property>
@@ -795,55 +874,7 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Randomize Pokémon Spawns?</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Randomize Traps?</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">5</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Mode</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Randomize Boss Room Layouts?</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">6</property>
+                            <property name="top-attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -863,27 +894,31 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">3</property>
+                            <property name="top-attach">2</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkButton" id="help_dungeons_mode">
+                          <object class="GtkSwitch" id="switch_dungeons_items">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
                             <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="icon-name">skytemple-help-about-symbolic</property>
-                              </object>
-                            </child>
+                            <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Randomize Pokémon Spawns?</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -903,6 +938,30 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
+                            <property name="top-attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="switch_dungeons_pokemon">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Randomize Traps?</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
                             <property name="top-attach">4</property>
                           </packing>
                         </child>
@@ -923,6 +982,30 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
+                            <property name="top-attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="switch_dungeons_traps">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Randomize Boss Room Layouts?</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
                             <property name="top-attach">5</property>
                           </packing>
                         </child>
@@ -943,61 +1026,6 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">6</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBox" id="cb_dungeons_mode">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="model">store_cb_dungeons_mode</property>
-                            <property name="active">0</property>
-                            <property name="id-column">0</property>
-                            <child>
-                              <object class="GtkCellRendererText"/>
-                              <attributes>
-                                <attribute name="text">1</attribute>
-                              </attributes>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="switch_dungeons_items">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="active">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="switch_dungeons_pokemon">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="active">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="switch_dungeons_traps">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="active">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">2</property>
                             <property name="top-attach">5</property>
                           </packing>
                         </child>
@@ -1010,27 +1038,129 @@ shop and dungeon rewards?</property>
                           </object>
                           <packing>
                             <property name="left-attach">2</property>
-                            <property name="top-attach">6</property>
+                            <property name="top-attach">5</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBox" id="cb_dungeons_weather">
+                          <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="model">store_cb_dungeons_weather</property>
-                            <property name="active">2</property>
-                            <property name="id-column">0</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Max sticky item chance</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">3</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Max monster house chance</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">3</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="help_dungeons_max_sticky_chance">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
                             <child>
-                              <object class="GtkCellRendererText"/>
-                              <attributes>
-                                <attribute name="text">1</attribute>
-                              </attributes>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                              </object>
                             </child>
                           </object>
                           <packing>
-                            <property name="left-attach">2</property>
+                            <property name="left-attach">4</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="help_dungeons_max_mh_chance">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">4</property>
                             <property name="top-attach">2</property>
                           </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="scale_dungeons_max_sticky_chance">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="adjustment">adjustment_max_sticky_chance</property>
+                            <property name="fill-level">100</property>
+                            <property name="round-digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="value-pos">right</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">5</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="scale_dungeons_max_mh_chance">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="adjustment">adjustment_max_mh_chance</property>
+                            <property name="fill-level">100</property>
+                            <property name="round-digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="value-pos">right</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">5</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                         <style>
                           <class name="back_illust"/>

--- a/skytemple_randomizer/randomizer/dungeon.py
+++ b/skytemple_randomizer/randomizer/dungeon.py
@@ -353,9 +353,10 @@ class DungeonRandomizer(AbstractRandomizer):
             floor_connectivity=randrange(5, 51),
             initial_enemy_density=randrange(1, 14),
             kecleon_shop_chance=randrange(0, 101),
-            monster_house_chance=randrange(0, 101) if allow_monster_houses else 0,
+            monster_house_chance=
+                randrange(0, self.config['dungeons']['max_mh_chance'].value + 1) if allow_monster_houses else 0,
             unusued_chance=randrange(0, 101),
-            sticky_item_chance=randrange(0, 101),
+            sticky_item_chance=randrange(0, self.config['dungeons']['max_sticky_chance'].value + 1),
             dead_ends=choice((True, False)),
             secondary_terrain=SECONDARY_TERRAIN_TILESET_MAP[tileset],
             terrain_settings=MappaFloorTerrainSettings(


### PR DESCRIPTION
Adds two sliders that can be used to set the maximum sticky item chance and monster house chance when randomizing floor data.
Closes #24 and #32.