### PR TITLE
[Feature] Add option to keep universal IQ skills in all groups.

### DIFF
--- a/skytemple_randomizer/config.py
+++ b/skytemple_randomizer/config.py
@@ -341,6 +341,7 @@ class IqConfig(TypedDict):
     randomize_iq_gain: bool
     randomize_iq_skills: bool
     randomize_iq_groups: bool
+    keep_universal_skills: bool
 
 
 class IqConfigDoc:
@@ -352,6 +353,10 @@ class IqConfigDoc:
         """If enabled, IQ skills are unlocked at random IQ amounts. Item Master is always unlocked."""
     randomize_iq_groups = \
         """If enabled, IQ skills are assigned to random IQ groups (but at least one). Item Master is always in all groups."""
+    keep_universal_skills = \
+        """If enabled, all skills that are in all groups base game will also be in all groups when randomized.
+        Course Checker, Item Catcher, Item Master, and Exclusive Move-User will be unlocked from the start.
+        Status Checker, Nontraitor, and Lava Evader will have randomized values unless random IQ amounts is disabled."""
 
 
 class ItemAlgorithm(Enum):
@@ -501,7 +506,8 @@ class ConfigFileLoader:
                             'randomize_tactics': False,
                             'randomize_iq_gain': False,
                             'randomize_iq_skills': False,
-                            'randomize_iq_groups': False
+                            'randomize_iq_groups': False,
+                            'keep_universal_skills': False
                         }
                     elif field == 'item' and field_type == ItemConfig:
                         target[field] = {

--- a/skytemple_randomizer/config.py
+++ b/skytemple_randomizer/config.py
@@ -354,9 +354,9 @@ class IqConfigDoc:
     randomize_iq_groups = \
         """If enabled, IQ skills are assigned to random IQ groups (but at least one). Item Master is always in all groups."""
     keep_universal_skills = \
-        """If enabled, all skills that are in all groups base game will also be in all groups when randomized.
-        Course Checker, Item Catcher, Item Master, and Exclusive Move-User will be unlocked from the start.
-        Status Checker, Nontraitor, and Lava Evader will have randomized values unless random IQ amounts is disabled."""
+        """If enabled, all skills that are included in all groups in the base game will also be added to all groups when randomizing\n.
+        On top of that, even if "randomize IQ skill unlocks" is enabled, Course Checker, Item Catcher, Item Master, and Exclusive Move-User will always be unlocked from the start.
+        However, Status Checker, Nontraitor, and Lava Evader will still have randomized IQ values."""
 
 
 class ItemAlgorithm(Enum):

--- a/skytemple_randomizer/data/default.json
+++ b/skytemple_randomizer/data/default.json
@@ -236,7 +236,8 @@
     "randomize_tactics": false,
     "randomize_iq_gain": false,
     "randomize_iq_skills": false,
-    "randomize_iq_groups": false
+    "randomize_iq_groups": false,
+    "keep_universal_skills": false
   },
   "quiz": {
     "mode": 1,

--- a/skytemple_randomizer/frontend/gtk/skytemple_randomizer.glade
+++ b/skytemple_randomizer/frontend/gtk/skytemple_randomizer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <requires lib="gtksourceview" version="4.0"/>
@@ -3550,10 +3550,11 @@ Try pressing A+B+X+Y if you get stuck in a cutscene.</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
-                      <!-- n-columns=3 n-rows=4 -->
+                      <!-- n-columns=6 n-rows=5 -->
                       <object class="GtkGrid">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="halign">start</property>
                         <property name="margin-left">5</property>
                         <property name="margin-right">5</property>
                         <property name="margin-start">5</property>
@@ -3737,6 +3738,94 @@ Try pressing A+B+X+Y if you get stuck in a cutscene.</property>
                             <property name="left-attach">2</property>
                             <property name="top-attach">3</property>
                           </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Keep Universal Skills?</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">3</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="help_iq_keep_universal_skills">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">4</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="switch_iq_keep_universal_skills">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">5</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                         <style>
                           <class name="back_illust"/>

--- a/skytemple_randomizer/randomizer/iq_tactics.py
+++ b/skytemple_randomizer/randomizer/iq_tactics.py
@@ -24,7 +24,6 @@ from skytemple_files.hardcoded.iq import HardcodedIq, IqGroupsSkills
 from skytemple_files.hardcoded.tactics import HardcodedTactics
 from skytemple_files.patch.patches import Patcher
 from skytemple_randomizer.randomizer.abstract import AbstractRandomizer
-from skytemple_randomizer.randomizer.util.util import get_main_string_file
 from skytemple_randomizer.status import Status
 
 
@@ -125,7 +124,6 @@ class IqTacticsRandomizer(AbstractRandomizer):
         if self.config['iq']['randomize_iq_skills']:
             status.step('Randomizing IQ skills...')
             iq_skills = HardcodedIq.get_iq_skills(arm9, self.static_data)
-            strings = get_main_string_file(self.rom, self.static_data)[1].strings
 
             for skill_idx, skill in enumerate(iq_skills):
                 if skill.iq_required != 9999:

--- a/skytemple_randomizer/randomizer/iq_tactics.py
+++ b/skytemple_randomizer/randomizer/iq_tactics.py
@@ -24,6 +24,7 @@ from skytemple_files.hardcoded.iq import HardcodedIq, IqGroupsSkills
 from skytemple_files.hardcoded.tactics import HardcodedTactics
 from skytemple_files.patch.patches import Patcher
 from skytemple_randomizer.randomizer.abstract import AbstractRandomizer
+from skytemple_randomizer.randomizer.util.util import get_main_string_file
 from skytemple_randomizer.status import Status
 
 
@@ -112,21 +113,32 @@ class IqTacticsRandomizer(AbstractRandomizer):
                 li2: List[u8] = []
                 new_iq_groups.append(li2)
                 for idx in range(len(iq_skills)):
-                    if idx == 22 or choice([True, False]):
-                        li2.append(u8(idx))
+                    if self.config['iq']['keep_universal_skills']:
+                        if idx in [2, 3, 7, 8, 20, 22, 23] or choice([True, False]):
+                            li2.append(u8(idx))
+                    else:
+                        if idx in [22] or choice([True, False]):
+                            li2.append(u8(idx))
 
             IqGroupsSkills.write_compressed(arm9, new_iq_groups, self.static_data)
 
         if self.config['iq']['randomize_iq_skills']:
             status.step('Randomizing IQ skills...')
             iq_skills = HardcodedIq.get_iq_skills(arm9, self.static_data)
+            strings = get_main_string_file(self.rom, self.static_data)[1].strings
 
             for skill_idx, skill in enumerate(iq_skills):
                 if skill.iq_required != 9999:
-                    if skill_idx == 22 or choice([True] + [False] * 12):
-                        skill.iq_required = i32(-1)
+                    if self.config['iq']['keep_universal_skills']:
+                        if skill_idx in [2, 3, 22, 23] or choice([True] + [False] * 12):
+                            skill.iq_required = i32(-1)
+                        else:
+                            skill.iq_required = i32(randrange(1, 900))
                     else:
-                        skill.iq_required = i32(randrange(1, 900))
+                        if skill_idx in [22] or choice([True] + [False] * 12):
+                            skill.iq_required = i32(-1)
+                        else:
+                            skill.iq_required = i32(randrange(1, 900))
 
             HardcodedIq.set_iq_skills(iq_skills, arm9, self.static_data)
 


### PR DESCRIPTION
When randomizing IQ skills, its really annoying when your partner attacks you (since the randomizer removes `Course Checker` from the base kit). I actually found it so annoying I made this PR, I also made it an option because having a really dumb partner can be fun sometimes (but not for full runs imo).