### PR TITLE
Apply NoWeatherStop patch

### DIFF
--- a/skytemple_randomizer/randomizer/patch_applier.py
+++ b/skytemple_randomizer/randomizer/patch_applier.py
@@ -74,6 +74,9 @@ class PatchApplier(AbstractRandomizer):
             if not patcher.is_applied('ReduceJumpcutPauseTime'):
                 patcher.apply('ReduceJumpcutPauseTime')
 
+        if not patcher.is_applied('NoWeatherStop'):
+            patcher.apply('NoWeatherStop')
+
         if self.config['quiz']['mode'] != QuizMode.TEST:
             status.step("Apply personality test patches...")
             if not patcher.is_applied('ChooseStarter'):


### PR DESCRIPTION
Applies the new NoWeatherStop patch by default. Useful since bad weather floors are common in randomized games.
Requires https://github.com/SkyTemple/skytemple-files/pull/353.