### PR TITLE
Reimplement text/script replacement algorithm for NPC replacement

### DIFF
--- a/CLI_API.md
+++ b/CLI_API.md
@@ -354,6 +354,12 @@ Type: Boolean
 If true, NPCs are randomized. Other places were NPCs appear are also changed if technically possible 
 (boss fights, special episode player characters, etc.).
 
+#### `.starters.npcs_use_smart_replace`
+Type: Boolean
+
+If true, use a more exhaustive algorithm for replacing in-game mentions of NPCs.
+This is typically slower than doing a simple replacement.
+
 #### `.starters_npcs.overworld_music`
 Type: Boolean
 

--- a/skytemple_randomizer/config.py
+++ b/skytemple_randomizer/config.py
@@ -60,6 +60,7 @@ class IntRange:
 class StartersNpcsConfig(TypedDict):
     starters: bool
     npcs: bool  # and bosses
+    npcs_use_smart_replace: bool
     topmenu_music: bool
     overworld_music: bool
     explorer_rank_unlocks: bool
@@ -1139,6 +1140,8 @@ class ConfigFileLoader:
                             },
                         }
                     elif field == "include_vanilla_questions":
+                        target[field] = False
+                    elif field == "npcs_use_smart_replace":
                         target[field] = False
                     else:
                         raise KeyError(

--- a/skytemple_randomizer/data/default.json
+++ b/skytemple_randomizer/data/default.json
@@ -6,7 +6,8 @@
     "overworld_music": false,
     "explorer_rank_unlocks": false,
     "explorer_rank_rewards": true,
-    "native_file_handlers": true
+    "native_file_handlers": true,
+    "npcs_use_smart_replace": true
   },
   "dungeons": {
     "mode": 0,

--- a/skytemple_randomizer/frontend/gtk/ui_util.py
+++ b/skytemple_randomizer/frontend/gtk/ui_util.py
@@ -46,7 +46,7 @@ Cipnit (via CTC patch) https://www.pokecommunity.com/member.php?u=751556
 Adex (via patches + JP support) https://github.com/Adex-8x
 Darkaim (JP support)
 Laioxy (JP support via pmdsky-debug) https://github.com/Laioxy
-in2erval (via patches + JP support) https://github.com/in2erval
+in2erval (code contributions) https://github.com/in2erval
 Please see GitHub for more minor contributors.
 
 Lead Hackers:

--- a/skytemple_randomizer/frontend/gtk/ui_util.py
+++ b/skytemple_randomizer/frontend/gtk/ui_util.py
@@ -46,6 +46,7 @@ Cipnit (via CTC patch) https://www.pokecommunity.com/member.php?u=751556
 Adex (via patches + JP support) https://github.com/Adex-8x
 Darkaim (JP support)
 Laioxy (JP support via pmdsky-debug) https://github.com/Laioxy
+in2erval (via patches + JP support) https://github.com/in2erval
 Please see GitHub for more minor contributors.
 
 Lead Hackers:

--- a/skytemple_randomizer/frontend/gtk/widgets/page_monsters.blp
+++ b/skytemple_randomizer/frontend/gtk/widgets/page_monsters.blp
@@ -48,7 +48,7 @@ template $StMonstersPage: Adw.PreferencesPage {
                 MenuButton {
                     icon-name: 'skytemple-help-about-symbolic';
                     popover: $StHelpPopover {
-                        label: _('If enabled all NPCs are randomized and all mentions of them\nin the script*.\nAdditionally the following things are also randomized with these new NPCs:\nBoss fights, Guest Pokémon, Special Episode Player Characters\n\n*: Some additional text in the game may also be affected  \n(eg. some item names).');
+                        label: _('If enabled all NPCs are randomized and all mentions of them\nin the script.\nAdditionally the following things are also randomized with these new NPCs:\nBoss fights, Guest Pokémon, Special Episode Player Characters');
                     };
                     styles ['flat']
                 }

--- a/skytemple_randomizer/frontend/gtk/widgets/page_text.blp
+++ b/skytemple_randomizer/frontend/gtk/widgets/page_text.blp
@@ -107,5 +107,25 @@ template $StTextPage: Adw.PreferencesPage {
             activatable: true;
             notify::active => $on_row_enable_instant_text_notify_active();
         }
+
+        Adw.ComboRow row_text_replacement_algorithm {
+            title: _('Text Replacement Algorithm');
+            icon-name: 'skytemple-e-string-symbolic';
+            activatable: true;
+            notify::selected => $on_row_text_replacement_algorithm_notify_selected();
+            model: StringList {
+                strings [_("Smart"), _("Classic")]
+            };
+            [suffix]
+            Box {
+                MenuButton {
+                    icon-name: 'skytemple-help-about-symbolic';
+                    popover: $StHelpPopover {
+                        label: _("Controls how Pokémon and NPC names in texts are replaced.\n\nSmart: Use a more expanded algorithm for replacing in-game mentions of NPCs.\nThis is typically slower than doing a simple replacement.\n\nClassic: Algorithm that was used in the Randomizer prior to version 2.0.\nIt may lead to some unrelated parts of text (such as parts of item names) being incorrectly replaced.");
+                    };
+                    styles ['flat']
+                }
+            }
+        }
     }
 }

--- a/skytemple_randomizer/frontend/gtk/widgets/page_text.blp
+++ b/skytemple_randomizer/frontend/gtk/widgets/page_text.blp
@@ -121,7 +121,7 @@ template $StTextPage: Adw.PreferencesPage {
                 MenuButton {
                     icon-name: 'skytemple-help-about-symbolic';
                     popover: $StHelpPopover {
-                        label: _("Controls how Pokémon and NPC names in texts are replaced.\n\nSmart: Use a more expanded algorithm for replacing in-game mentions of NPCs.\nThis is typically slower than doing a simple replacement.\n\nClassic: Algorithm that was used in the Randomizer prior to version 2.0.\nIt may lead to some unrelated parts of text (such as parts of item names) being incorrectly replaced.");
+                        label: _("Controls how Pokémon and NPC names in texts are replaced.\n\nClassic: Algorithm that was used in the Randomizer prior to version 2.0.\nIt may lead to some unrelated parts of text (such as parts of item names) being incorrectly replaced.\n\nSmart: Use a more exhaustive algorithm for replacing in-game mentions of NPCs.\nThis is typically slower than doing a simple replacement.");
                     };
                     styles ['flat']
                 }

--- a/skytemple_randomizer/frontend/gtk/widgets/page_text.py
+++ b/skytemple_randomizer/frontend/gtk/widgets/page_text.py
@@ -52,6 +52,7 @@ class TextPage(Adw.PreferencesPage):
     row_randomize_main_text = cast(Adw.SwitchRow, Gtk.Template.Child())
     row_randomize_story_dialogue = cast(Adw.SwitchRow, Gtk.Template.Child())
     row_enable_instant_text = cast(Adw.SwitchRow, Gtk.Template.Child())
+    row_text_replacement_algorithm = cast(Adw.ComboRow, Gtk.Template.Child())
     group_full_text_randomization = cast(Adw.PreferencesGroup, Gtk.Template.Child())
 
     randomization_settings: RandomizerConfig | None
@@ -170,6 +171,15 @@ class TextPage(Adw.PreferencesPage):
             self.row_enable_instant_text.get_active()
         )
 
+    @Gtk.Template.Callback()
+    def on_row_text_replacement_algorithm_notify_selected(self, *args):
+        if self._suppress_signals:
+            return
+        assert self.randomization_settings is not None
+        self.randomization_settings["starters_npcs"]["npcs_use_smart_replace"] = (
+            self.row_text_replacement_algorithm.get_selected() == 0
+        )
+
     def populate_settings(self, config: RandomizerConfig):
         self._suppress_signals = True
         self.randomization_settings = config
@@ -179,6 +189,12 @@ class TextPage(Adw.PreferencesPage):
         self.row_randomize_main_text.set_active(config["text"]["main"])
         self.row_randomize_story_dialogue.set_active(config["text"]["story"])
         self.row_enable_instant_text.set_active(config["text"]["instant"])
+        replacement_algo = (
+            0
+            if self.randomization_settings["starters_npcs"]["npcs_use_smart_replace"]
+            else 1
+        )
+        self.row_text_replacement_algorithm.set_selected(replacement_algo)
         self._suppress_signals = False
 
         # The JP ROM does not support these yet:

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -1,4 +1,4 @@
-#  Copyright 2020-2023 Capypara and the SkyTemple Contributors
+#  Copyright 2020-2024 Capypara and the SkyTemple Contributors
 #
 #  This file is part of SkyTemple.
 #

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -224,7 +224,7 @@ class NpcRandomizer(AbstractRandomizer):
                     for block in kecleon_replace_regions
                     if block is not None
                 ):
-                    new_text = kecleon_shop_text[lang.name_localized].sub(
+                    new_text = kecleon_shop_text[lang.name].sub(
                         lambda match: match.string[match.start(0) : match.start(1)]
                         + mapped_actor_names[match.group(1)]
                         + match.string[match.end(1) : match.end(0)],

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -126,7 +126,7 @@ class NpcRandomizer(AbstractRandomizer):
             # Some [CS:K]...[CR] needs replacing for Kecleon, Chansey, Marowak, Spinda, Chimecho, Mime Jr., Electivire, and all the Pokemon under the Adventure Log.
             # We need to specifically select string block regions to apply this to.
             csk_npc_text = re.compile(
-                r"\[CS:K](" + "|".join(list(mapped_actor_names.keys())) + r")\[CR]"
+                r"\[CS:K](.*)(" + "|".join(list(mapped_actor_names.keys())) + r")(.*)\[CR]"
             )
             csk_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(
@@ -215,7 +215,7 @@ class NpcRandomizer(AbstractRandomizer):
                 ):
                     new_text = csk_npc_text.sub(
                         lambda match: match.expand(
-                            f"[CS:K]{mapped_actor_names[match.group(1)]}[CR]"
+                            f"[CS:K]{match.group(1)}{mapped_actor_names[match.group(2)]}{match.group(3)}[CR]"
                         ),
                         new_text,
                     )

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -1,4 +1,4 @@
-#  Copyright 2020-2024 Capypara and the SkyTemple Contributors
+#  Copyright 2020-2023 Capypara and the SkyTemple Contributors
 #
 #  This file is part of SkyTemple.
 #
@@ -14,10 +14,13 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import re
 from random import choice, randrange
 
 from range_typed_integers import u16
+from skytemple_files.common.i18n_util import _
 from skytemple_files.common.types.file_types import FileType
+from skytemple_files.common.util import get_files_from_rom_with_extension
 from skytemple_files.data.md.protocol import Gender
 from skytemple_files.data.str.model import Str
 from skytemple_files.list.actor.model import ActorListBin
@@ -26,14 +29,13 @@ from skytemple_randomizer.randomizer.abstract import AbstractRandomizer
 from skytemple_randomizer.randomizer.util.util import (
     get_main_string_file,
     get_allowed_md_ids,
-    replace_text_main,
-    replace_text_script,
+    get_script,
     clone_missing_portraits,
     get_all_string_files,
+    SKIP_JP_INVALID_SSB,
     Roster,
 )
 from skytemple_randomizer.status import Status
-from skytemple_files.common.i18n_util import _
 
 
 class NpcRandomizer(AbstractRandomizer):
@@ -45,7 +47,7 @@ class NpcRandomizer(AbstractRandomizer):
     def run(self, status: Status):
         if not self.config["starters_npcs"]["npcs"]:
             return status.done()
-        lang, string_file = get_main_string_file(self.rom, self.static_data)
+        main_lang, main_string_file = get_main_string_file(self.rom, self.static_data)
         pokemon_string_data = self.static_data.string_index_data.string_blocks[
             "Pokemon Names"
         ]
@@ -56,31 +58,184 @@ class NpcRandomizer(AbstractRandomizer):
             patcher.apply("ActorAndLevelLoader")
 
         status.step(_("Randomizing NPC actor list..."))
-        mapped_actors = self._randomize_actors(string_file, pokemon_string_data)
+        mapped_actors = self._randomize_actors(main_string_file, pokemon_string_data)
+        mapped_actor_names_by_lang = {}
 
-        status.step(_("Replacing main text that mentions NPCs..."))
-        names_mapped_all = {}
-        for lang, string_file in get_all_string_files(self.rom, self.static_data):
+        for lang, lang_string_file in get_all_string_files(self.rom, self.static_data):
             names_mapped: dict[str, str] = {}
-            names_mapped_all[lang] = names_mapped
+            mapped_actor_names_by_lang[lang] = names_mapped
             for old, new in mapped_actors.items():
                 old_base = old % 600
                 new_base = new % 600
-                old_name = self._get_name(string_file, old_base, pokemon_string_data)
-                new_name = self._get_name(string_file, new_base, pokemon_string_data)
+                old_name = self._get_name(
+                    lang_string_file, old_base, pokemon_string_data
+                )
+                new_name = self._get_name(
+                    lang_string_file, new_base, pokemon_string_data
+                )
                 names_mapped[old_name] = new_name
-            replace_text_main(
-                string_file,
-                names_mapped,
-                pokemon_string_data.begin,
-                pokemon_string_data.end,
+
+        status.step(_("Replacing main text that mentions NPCs..."))
+        for lang, lang_string_file in get_all_string_files(self.rom, self.static_data):
+            mapped_actor_names = mapped_actor_names_by_lang[lang]
+
+            # Most NPC texts in the base game are wrapped via [CN:N]...[CR], or [CN:Y]...[CR].
+            # Croagunk is the only NPC pokemon that has texts with [CS:E].
+            standard_npc_text = re.compile(
+                r"\[CS:(N|Y|E)]("
+                + "|".join(list(mapped_actor_names.keys()))
+                + r")\[CR]"
             )
+            # Some place names derived from NPCs are mentioned via [CS:P]...[CR], so we'll replace those as well.
+            place_mention_npc_text = re.compile(
+                r"\[CS:P](.*)("
+                + "|".join(list(mapped_actor_names.keys()))
+                + r")(.*)\[CR]"
+            )
+            # Some [CS:K]...[CR] needs replacing for Kecleon, Chansey, Marowak, Spinda, Chimecho, Mime Jr., Electivire, and all the Pokemon under the Adventure Log.
+            # We need to specifically select string block regions to apply this to.
+            csk_npc_text = re.compile(
+                r"\[CS:K](" + "|".join(list(mapped_actor_names.keys())) + r")\[CR]"
+            )
+            csk_replace_regions = [
+                self.static_data.string_index_data.string_blocks.get(
+                    "Job Debriefing Related Strings"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "(MAROWAK-DOJO-STRS-UNMAPPED)"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Spinda's Juice Bar Strings"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "(CHIMECHO-ASM-STR-UNMAPPED)"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Game and Dungeon Hints"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Mime Jr. Spa Strings"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Adventure Log Strings"
+                ),
+            ]
+            # Kecleon needs extra care, because some item long descriptions contain references to the shop (should be replaced) and the Pokemon itself (should not be replaced) at the same time.
+            # Instead we replace some of the mentions of the specific text "Kecleon's Shop" (note: things like music track names should not be replaced).
+            kecleon_shop_text = {
+                # IMPORTANT: match.group(1) should always be Kecleon's name
+                "English": re.compile(r"(Kecleon)(?:\[CR])?'s Shop"),
+                "French": re.compile(r"Magasins\n?(Kecleon)"),
+                "German": re.compile(r"(Kecleon)-Laden"),
+                "Italian": re.compile(r"Magazzini\n?(?:\[CS:.])?(Kecleon)"),
+                "Spanish": re.compile(r"Tienda\n?(Kecleon)"),
+                "Japanese": re.compile(r"(カクレオン)(?:\[CR])?の\n?お?みせ"),
+            }
+            kecleon_replace_regions = [
+                self.static_data.string_index_data.string_blocks.get(
+                    "Floor-Wide Status Names+Desc"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Item Long Descriptions"
+                ),
+            ]
+            # Finally, there are plain texts that need replacing for a bunch of Pokemons (typically chapter texts and place names)
+            plain_npc_text = re.compile(
+                "(" + "|".join(list(mapped_actor_names.keys())) + ")"
+            )
+            plain_replace_regions = [
+                self.static_data.string_index_data.string_blocks.get(
+                    "(SPECIAL-EPISODES-STRS-UNMAPPED)"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "(JOURNAL-STRS-UNMAPPED)"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Pokemon WAIT Dialogue"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Ground Map Names"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Dungeon Names (Main)"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Dungeon Names (Section)"
+                ),
+            ]
+
+            for idx, text in enumerate(lang_string_file.strings):
+                new_text = standard_npc_text.sub(
+                    lambda match: match.expand(
+                        f"[CS:{match.group(1)}]{mapped_actor_names[match.group(2)]}[CR]"
+                    ),
+                    text,
+                )
+                new_text = place_mention_npc_text.sub(
+                    lambda match: match.expand(
+                        f"[CS:P]{match.group(1)}{mapped_actor_names[match.group(2)]}{match.group(3)}[CR]"
+                    ),
+                    new_text,
+                )
+                if any(
+                    block.begin < idx < block.end
+                    for block in csk_replace_regions
+                    if block is not None
+                ):
+                    new_text = csk_npc_text.sub(
+                        lambda match: match.expand(
+                            f"[CS:K]{mapped_actor_names[match.group(1)]}[CR]"
+                        ),
+                        new_text,
+                    )
+                if any(
+                    block.begin < idx < block.end
+                    for block in kecleon_replace_regions
+                    if block is not None
+                ):
+                    new_text = kecleon_shop_text[lang.name_localized].sub(
+                        lambda match: match.string[match.start(0) : match.start(1)]
+                        + mapped_actor_names[match.group(1)]
+                        + match.string[match.end(1) : match.end(0)],
+                        new_text,
+                    )
+                if any(
+                    block.begin < idx < block.end
+                    for block in plain_replace_regions
+                    if block is not None
+                ):
+                    new_text = plain_npc_text.sub(
+                        lambda match: mapped_actor_names[match.group(1)], new_text
+                    )
+                lang_string_file.strings[idx] = new_text
+
             self.rom.setFileByName(
-                f"MESSAGE/{lang.filename}", FileType.STR.serialize(string_file)
+                f"MESSAGE/{lang.filename}", FileType.STR.serialize(lang_string_file)
             )
 
         status.step(_("Replacing script text that mentions NPCs..."))
-        replace_text_script(self.rom, self.static_data, names_mapped_all)
+        # We don't need to be selective with script text - we should be able to replace all mentions of the NPC names directly.
+        # To avoid improper substring matching, we need to construct the regex so that the longer strings are matched first.
+        script_npc_text = re.compile(
+            "|".join(sorted(list(mapped_actor_names.keys()), key=len, reverse=True))
+        )
+        for file_path in get_files_from_rom_with_extension(self.rom, "ssb"):
+            if file_path in SKIP_JP_INVALID_SSB:
+                continue
+            script = get_script(file_path, self.rom, self.static_data)
+            script.constants = [
+                script_npc_text.sub(
+                    lambda match: mapped_actor_names[match.group(0)], text
+                )
+                for text in script.constants
+            ]
+            if len(script.strings) > 0:  # for Japanese this is empty.
+                script.strings[lang.name.lower()] = [
+                    script_npc_text.sub(
+                        lambda match: mapped_actor_names[match.group(0)], text
+                    )
+                    for text in script.strings[lang.name.lower()]
+                ]
 
         status.step(_("Cloning missing NPC portraits..."))
         kao = FileType.KAO.deserialize(self.rom.getFileByName("FONT/kaomado.kao"))

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -110,7 +110,9 @@ class NpcRandomizer(AbstractRandomizer):
     def _smart_replace_text(self, mapped_actor_names_by_lang):
         for lang, lang_string_file in get_all_string_files(self.rom, self.static_data):
             mapped_actor_names = mapped_actor_names_by_lang[lang]
-            sorted_actor_names = sorted(list(mapped_actor_names.keys()), key=len, reverse=True)
+            sorted_actor_names = sorted(
+                list(mapped_actor_names.keys()), key=len, reverse=True
+            )
             # Most NPC texts in the base game are wrapped via [CN:N]...[CR], or [CN:Y]...[CR].
             # Some place names derived from NPCs are mentioned via [CS:P]...[CR], so we'll replace those as well.
             # Croagunk's Swap Shop is mentioned via [CS:E].
@@ -122,7 +124,9 @@ class NpcRandomizer(AbstractRandomizer):
             # Some [CS:K]...[CR] needs replacing for Kecleon, Chansey, Marowak, Spinda, Chimecho, Mime Jr., Electivire, and all the Pokemon under the Adventure Log.
             # We need to specifically select string block regions to apply this to.
             csk_npc_text = re.compile(
-                r"\[CS:K]((?:\s|.)*?)(" + "|".join(sorted_actor_names) + r")((?:\s|.)*?)\[CR]"
+                r"\[CS:K]((?:\s|.)*?)("
+                + "|".join(sorted_actor_names)
+                + r")((?:\s|.)*?)\[CR]"
             )
             csk_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -612,7 +612,10 @@ def replace_strings(original: str, replacement_map: dict[str, str]):
         string = string.replace(old, new)
     return string
 
-def replace_text_main(string_file: Str, replace_map: dict[str, str], start_idx, end_idx):
+
+def replace_text_main(
+    string_file: Str, replace_map: dict[str, str], start_idx, end_idx
+):
     new_strings = []
     for idx, string in enumerate(string_file.strings):
         if idx < start_idx or idx > end_idx:
@@ -620,6 +623,7 @@ def replace_text_main(string_file: Str, replace_map: dict[str, str], start_idx, 
         else:
             new_strings.append(string)
     string_file.strings = new_strings
+
 
 def replace_text_script(
     rom: NintendoDSRom,

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -612,6 +612,14 @@ def replace_strings(original: str, replacement_map: dict[str, str]):
         string = string.replace(old, new)
     return string
 
+def replace_text_main(string_file: Str, replace_map: dict[str, str], start_idx, end_idx):
+    new_strings = []
+    for idx, string in enumerate(string_file.strings):
+        if idx < start_idx or idx > end_idx:
+            new_strings.append(replace_strings(string, replace_map))
+        else:
+            new_strings.append(string)
+    string_file.strings = new_strings
 
 def replace_text_script(
     rom: NintendoDSRom,

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -664,7 +664,6 @@ def clear_script_cache_for(file_path):
 
 def get_script(file_path, rom, static_data):
     global _ssb_file_cache
-    assert "S00P01A/enter00.ssb" not in file_path
     if file_path not in _ssb_file_cache:
         _ssb_file_cache[file_path] = FileType.SSB.deserialize(
             rom.getFileByName(file_path), static_data

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -664,6 +664,7 @@ def clear_script_cache_for(file_path):
 
 def get_script(file_path, rom, static_data):
     global _ssb_file_cache
+    assert "S00P01A/enter00.ssb" not in file_path
     if file_path not in _ssb_file_cache:
         _ssb_file_cache[file_path] = FileType.SSB.deserialize(
             rom.getFileByName(file_path), static_data

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -613,18 +613,6 @@ def replace_strings(original: str, replacement_map: dict[str, str]):
     return string
 
 
-def replace_text_main(
-    string_file: Str, replace_map: dict[str, str], start_idx, end_idx
-):
-    new_strings = []
-    for idx, string in enumerate(string_file.strings):
-        if idx < start_idx or idx > end_idx:
-            new_strings.append(replace_strings(string, replace_map))
-        else:
-            new_strings.append(string)
-    string_file.strings = new_strings
-
-
 def replace_text_script(
     rom: NintendoDSRom,
     static_data: Pmd2Data,


### PR DESCRIPTION
This PR aims to address a few issues with the current NPC randomisation:
- Fix replacement method to do a _single pass through each text_. Previously this was looping _per replaced NPC_ and thus was performing multiple replacements per text, which led to unexpected replacements happening multiple times (e.g. "Charmander" -(map)-> "Porygon Z" -(map substr)-> "Bidoof Z")
- Similar to above, the replacement now searches for colour codes as they allow for more reliable searching of NPC names.
- Expanded the replacement into multiple categories to cover text usages more comprehensively.

There are some `Pmd2StringIndexData` IDs that have been added to this that currently don't exist in the [XML](https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/_resources/ppmdu_config/pmd2data.xml) - I'm planning to do a PR to expand this further to include things like Marowak Dojo strings and Game/Dungeon Hints. As of now they will end up being `None` which gets ignored until they start appearing in the `static_data`.