### PR TITLE
Fix issue with regex

### DIFF
--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -124,9 +124,7 @@ class NpcRandomizer(AbstractRandomizer):
             # Some [CS:K]...[CR] needs replacing for Kecleon, Chansey, Marowak, Spinda, Chimecho, Mime Jr., Electivire, and all the Pokemon under the Adventure Log.
             # We need to specifically select string block regions to apply this to.
             csk_npc_text = re.compile(
-                r"\[CS:K]([^\[]*)("
-                + "|".join(sorted_actor_names)
-                + r")([^\[]*)\[CR]"
+                r"\[CS:K]([^\[]*)(" + "|".join(sorted_actor_names) + r")([^\[]*)\[CR]"
             )
             csk_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -117,16 +117,16 @@ class NpcRandomizer(AbstractRandomizer):
             # Some place names derived from NPCs are mentioned via [CS:P]...[CR], so we'll replace those as well.
             # Croagunk's Swap Shop is mentioned via [CS:E].
             standard_npc_text = re.compile(
-                r"\[CS:(N|Y|P|E)]((?:\s|.)*?)("
+                r"\[CS:(N|Y|P|E)]([^\[]*)("
                 + "|".join(sorted_actor_names)
-                + r")((?:\s|.)*?)\[CR]"
+                + r")([^\[]*)\[CR]"
             )
             # Some [CS:K]...[CR] needs replacing for Kecleon, Chansey, Marowak, Spinda, Chimecho, Mime Jr., Electivire, and all the Pokemon under the Adventure Log.
             # We need to specifically select string block regions to apply this to.
             csk_npc_text = re.compile(
-                r"\[CS:K]((?:\s|.)*?)("
+                r"\[CS:K]([^\[]*)("
                 + "|".join(sorted_actor_names)
-                + r")((?:\s|.)*?)\[CR]"
+                + r")([^\[]*)\[CR]"
             )
             csk_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(


### PR DESCRIPTION
This fixes the issue where the regex was hanging the program - likely due to bad regex behaviour arising from `((?:\s|.)*)`.


<details><summary>Examples</summary>

![Screenshot 2024-04-07 224736](https://github.com/SkyTemple/skytemple-randomizer/assets/15063274/c0f85cc6-24ba-4ade-9f50-c976de6ff693)
![Screenshot 2024-04-07 224821](https://github.com/SkyTemple/skytemple-randomizer/assets/15063274/c466374c-467b-41fa-8f28-d83ad9f581f0)
![Screenshot 2024-04-07 224902](https://github.com/SkyTemple/skytemple-randomizer/assets/15063274/ee1732fa-eaf3-486b-935a-9e784dc12d3b)
![Screenshot 2024-04-07 225120](https://github.com/SkyTemple/skytemple-randomizer/assets/15063274/053f241f-8b27-4d50-a82c-0b25dfe0134d)

Works with newlines, e.g. in the French version's "Stand Troc Cradopaud":
![Screenshot 2024-04-07 225242](https://github.com/SkyTemple/skytemple-randomizer/assets/15063274/bc2d5624-c662-4311-a012-83a1b6413963)

</details> 