### PR TITLE
Implement string file caching and bazaar pokemon text replacement

### DIFF
--- a/skytemple_randomizer/randomizer/boss.py
+++ b/skytemple_randomizer/randomizer/boss.py
@@ -25,7 +25,12 @@ from skytemple_files.hardcoded.fixed_floor import HardcodedFixedFloorTables
 from skytemple_files.list.actor.model import ActorListBin
 from skytemple_files.patch.patches import Patcher
 from skytemple_randomizer.randomizer.abstract import AbstractRandomizer
-from skytemple_randomizer.randomizer.util.util import get_allowed_md_ids, get_pokemon_name, get_all_string_files, Roster
+from skytemple_randomizer.randomizer.util.util import (
+    get_allowed_md_ids,
+    get_pokemon_name,
+    get_all_string_files,
+    Roster,
+)
 from skytemple_randomizer.status import Status
 
 # Maps actor list indices to fixed room monster spawn indices.
@@ -243,17 +248,23 @@ class BossRandomizer(AbstractRandomizer):
         # Also update strings for bazaar monsters
         for lang, lang_string_file in get_all_string_files(self.rom, self.static_data):
             extra_ff_replace_name_map = {
-                get_pokemon_name(self.rom, self.static_data, old_monster_id, lang): get_pokemon_name(self.rom, self.static_data, new_monster_id, lang)
+                get_pokemon_name(
+                    self.rom, self.static_data, old_monster_id, lang
+                ): get_pokemon_name(self.rom, self.static_data, new_monster_id, lang)
                 for old_monster_id, new_monster_id in extra_ff_replace_map.items()
             }
-            replace_regex = re.compile(r"\[CS:(.)]([^\[]*)(" + "|".join(extra_ff_replace_name_map.keys()) + r")([^\[]*)\[CR]")
+            replace_regex = re.compile(
+                r"\[CS:(.)]([^\[]*)("
+                + "|".join(extra_ff_replace_name_map.keys())
+                + r")([^\[]*)\[CR]"
+            )
             for region in [r for r in extra_ff_str_replace_regions if r is not None]:
                 for idx in range(region.begin, region.end):
                     lang_string_file.strings[idx] = replace_regex.sub(
                         lambda match: match.expand(
                             f"[CS:{match.group(1)}]{match.group(2)}{extra_ff_replace_name_map[match.group(3)]}{match.group(4)}[CR]"
                         ),
-                        lang_string_file.strings[idx]
+                        lang_string_file.strings[idx],
                     )
             self.rom.setFileByName(
                 f"MESSAGE/{lang.filename}", FileType.STR.serialize(lang_string_file)

--- a/skytemple_randomizer/randomizer/boss.py
+++ b/skytemple_randomizer/randomizer/boss.py
@@ -14,6 +14,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import re
 from random import choice
 
 from range_typed_integers import u16
@@ -24,7 +25,7 @@ from skytemple_files.hardcoded.fixed_floor import HardcodedFixedFloorTables
 from skytemple_files.list.actor.model import ActorListBin
 from skytemple_files.patch.patches import Patcher
 from skytemple_randomizer.randomizer.abstract import AbstractRandomizer
-from skytemple_randomizer.randomizer.util.util import get_allowed_md_ids, Roster
+from skytemple_randomizer.randomizer.util.util import get_allowed_md_ids, get_pokemon_name, get_all_string_files, Roster
 from skytemple_randomizer.status import Status
 
 # Maps actor list indices to fixed room monster spawn indices.
@@ -193,7 +194,7 @@ EXTRA_FF_MONSTER_RANDOMIZE = [16, 18, 19, 20]
 class BossRandomizer(AbstractRandomizer):
     def step_count(self) -> int:
         if self.config["starters_npcs"]["npcs"]:
-            return 2
+            return 3
         return 0
 
     def run(self, status: Status):
@@ -222,9 +223,40 @@ class BossRandomizer(AbstractRandomizer):
                 for bi in ACTOR_TO_BOSS_MAPPING[i]:
                     boss_list[bi].md_idx = actor.entid
 
+        status.step(_("Updating bazaar monsters..."))
+        extra_ff_str_replace_regions = [
+            self.static_data.string_index_data.string_blocks.get(
+                "Kirlia Secret Bazaar Strings"
+            ),
+            self.static_data.string_index_data.string_blocks.get(
+                "Shedinja Shop Strings"
+            ),
+        ]
+        extra_ff_replace_map = {}
         for extra_id in EXTRA_FF_MONSTER_RANDOMIZE:
-            boss_list[extra_id].md_idx = u16(
+            old_monster_id = boss_list[extra_id].md_idx
+            new_monster_id = u16(
                 choice(get_allowed_md_ids(self.config, False, roster=Roster.NPCS))
+            )
+            boss_list[extra_id].md_idx = new_monster_id
+            extra_ff_replace_map[old_monster_id] = new_monster_id
+        # Also update strings for bazaar monsters
+        for lang, lang_string_file in get_all_string_files(self.rom, self.static_data):
+            extra_ff_replace_name_map = {
+                get_pokemon_name(self.rom, self.static_data, old_monster_id, lang): get_pokemon_name(self.rom, self.static_data, new_monster_id, lang)
+                for old_monster_id, new_monster_id in extra_ff_replace_map.items()
+            }
+            replace_regex = re.compile(r"\[CS:(.)]([^\[]*)(" + "|".join(extra_ff_replace_name_map.keys()) + r")([^\[]*)\[CR]")
+            for region in [r for r in extra_ff_str_replace_regions if r is not None]:
+                for idx in range(region.begin, region.end):
+                    lang_string_file.strings[idx] = replace_regex.sub(
+                        lambda match: match.expand(
+                            f"[CS:{match.group(1)}]{match.group(2)}{extra_ff_replace_name_map[match.group(3)]}{match.group(4)}[CR]"
+                        ),
+                        lang_string_file.strings[idx]
+                    )
+            self.rom.setFileByName(
+                f"MESSAGE/{lang.filename}", FileType.STR.serialize(lang_string_file)
             )
 
         HardcodedFixedFloorTables.set_monster_spawn_list(

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -60,7 +60,7 @@ class NpcRandomizer(AbstractRandomizer):
             patcher.apply("ActorAndLevelLoader")
 
         status.step(_("Randomizing NPC actor list..."))
-        mapped_actors = self._randomize_actors(main_string_file, pokemon_string_data)
+        mapped_actors = self._randomize_actors()
         mapped_actor_names_by_lang = {}
 
         for lang in self.static_data.string_index_data.languages:

--- a/skytemple_randomizer/randomizer/npc.py
+++ b/skytemple_randomizer/randomizer/npc.py
@@ -128,42 +128,60 @@ class NpcRandomizer(AbstractRandomizer):
             )
             csk_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(
-                    "Job Debriefing Related Strings"
+                    "Job Debriefing Related Strings (Secondary)"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
-                    "(MAROWAK-DOJO-STRS-UNMAPPED)"
+                    "Game Trade Strings"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
                     "Spinda's Juice Bar Strings"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
-                    "(CHIMECHO-ASM-STR-UNMAPPED)"
-                ),
-                self.static_data.string_index_data.string_blocks.get(
-                    "Game and Dungeon Hints"
+                    "Chimecho Assembly Strings"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
                     "Mime Jr. Spa Strings"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
-                    "Adventure Log Strings"
+                    "Adventure Log Entries"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "Floor-Wide Status"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
+                    "IQ Skills Descriptions"
                 ),
             ]
-            # Kecleon needs extra care, because some item long descriptions contain references to the shop (should be replaced) and the Pokemon itself (should not be replaced) at the same time.
-            # Instead we replace some of the mentions of the specific text "Kecleon's Shop" (note: things like music track names should not be replaced).
-            kecleon_shop_text = {
-                # IMPORTANT: match.group(1) should always be Kecleon's name
-                "English": re.compile(r"(Kecleon)(?:\[CR])?'s\sShop"),
-                "French": re.compile(r"Magasins\s(Kecleon)"),
-                "German": re.compile(r"(Kecleon)-Laden"),
-                "Italian": re.compile(r"Magazzini\s(?:\[CS:.])?(Kecleon)"),
-                "Spanish": re.compile(r"Tienda\s(Kecleon)"),
-                "Japanese": re.compile(r"(カクレオン)(?:\[CR])?の\s?お?みせ"),
+            # Some pokemons (Kecleon, Shaymin) need extra care, because some item long descriptions contain references to the shop (should be replaced) and the Pokemon itself (should not be replaced) at the same time.
+            # Instead we replace some of the mentions of the specific shop names (note: things like music track names should not be replaced).
+            shop_texts = {
+                # IMPORTANT: match.group(1) should always be the Pokemon name to replace
+                "English": [
+                    re.compile(r"(Kecleon)(?:\[CR])?'s\sShop"),
+                    re.compile(r"(Shaymin)(?:\[CR])?'s\sDelivery\sService"),
+                ],
+                "French": [
+                    re.compile(r"Magasins\s(Kecleon)"),
+                    re.compile(r"Service\sde\sLivraison\s(Shaymin)"),
+                ],
+                "German": [
+                    re.compile(r"(Kecleon)-Laden"),
+                    re.compile(r"(Shaymin)-Lieferservice"),
+                ],
+                "Italian": [
+                    re.compile(r"Magazzini\s(?:\[CS:.])?(Kecleon)"),
+                    re.compile(r"Servizio\sConsegne\s(?:\[CS:.])?(Shaymin)"),
+                ],
+                "Spanish": [
+                    re.compile(r"Repartos\s(Kecleon)"),
+                    re.compile(r"Service\sde\sLivraison\s(Shaymin)"),
+                ],
+                "Japanese": [
+                    re.compile(r"(カクレオン)(?:\[CR])?の\s?お?みせ"),
+                    re.compile(r"(シェイミ)(?:\[CR])?のたくはいびん"),
+                ]
             }
-            kecleon_replace_regions = [
-                self.static_data.string_index_data.string_blocks.get(
-                    "Floor-Wide Status Names+Desc"
-                ),
+            shop_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(
                     "Item Long Descriptions"
                 ),
@@ -174,13 +192,13 @@ class NpcRandomizer(AbstractRandomizer):
             )
             plain_replace_regions = [
                 self.static_data.string_index_data.string_blocks.get(
-                    "(SPECIAL-EPISODES-STRS-UNMAPPED)"
+                    "Special Episode Item Handling Strings"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
-                    "(JOURNAL-STRS-UNMAPPED)"
+                    "Chapter and Special Episode Strings"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
-                    "Pokemon WAIT Dialogue"
+                    "Game and Dungeon Hints"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
                     "Ground Map Names"
@@ -192,11 +210,15 @@ class NpcRandomizer(AbstractRandomizer):
                     "Dungeon Names (Selection)"
                 ),
                 self.static_data.string_index_data.string_blocks.get(
+                    "Dungeon Names (SetDungeonBanner)"
+                ),
+                self.static_data.string_index_data.string_blocks.get(
                     "Dungeon Names (Banner)"
                 ),
             ]
 
             for idx, text in enumerate(lang_string_file.strings):
+                string_id = idx + 1
                 new_text = standard_npc_text.sub(
                     lambda match: match.expand(
                         f"[CS:{match.group(1)}]{match.group(2)}{mapped_actor_names[match.group(3)]}{match.group(4)}[CR]"
@@ -204,7 +226,7 @@ class NpcRandomizer(AbstractRandomizer):
                     text,
                 )
                 if any(
-                    block.begin < idx < block.end
+                    block.begin < string_id <= block.end
                     for block in csk_replace_regions
                     if block is not None
                 ):
@@ -215,18 +237,19 @@ class NpcRandomizer(AbstractRandomizer):
                         new_text,
                     )
                 if any(
-                    block.begin < idx < block.end
-                    for block in kecleon_replace_regions
+                    block.begin < string_id <= block.end
+                    for block in shop_replace_regions
                     if block is not None
                 ):
-                    new_text = kecleon_shop_text[lang.name].sub(
-                        lambda match: match.string[match.start(0) : match.start(1)]
-                        + mapped_actor_names[match.group(1)]
-                        + match.string[match.end(1) : match.end(0)],
-                        new_text,
-                    )
+                    for shop_regex in shop_texts[lang.name]:
+                        new_text = shop_regex.sub(
+                            lambda match: match.string[match.start(0) : match.start(1)]
+                            + mapped_actor_names[match.group(1)]
+                            + match.string[match.end(1) : match.end(0)],
+                            new_text,
+                        )
                 if any(
-                    block.begin < idx < block.end
+                    block.begin < string_id <= block.end
                     for block in plain_replace_regions
                     if block is not None
                 ):

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -488,6 +488,14 @@ SKIP_JP_INVALID_SSB = [
 ]
 
 
+_str_file_cache: dict[Pmd2Language, Str] = {}
+
+
+def clear_strings_cache():
+    global _str_file_cache
+    _str_file_cache = {}
+
+
 def get_main_string_file(
     rom: NintendoDSRom, static_data: Pmd2Data
 ) -> tuple[Pmd2Language, Str]:
@@ -499,23 +507,25 @@ def get_main_string_file(
     # If we didn't find english, just take the first
     if lang is None:
         lang = static_data.string_index_data.languages[0]
-    return lang, FileType.STR.deserialize(
-        rom.getFileByName(f"MESSAGE/{lang.filename}"),
-        string_encoding=static_data.string_encoding,
-    )
+    return lang, get_lang_string_file(rom, static_data, lang)
 
 
 def get_all_string_files(
     rom: NintendoDSRom, static_data: Pmd2Data
 ) -> Iterable[tuple[Pmd2Language, Str]]:
     for lang in static_data.string_index_data.languages:
-        yield (
-            lang,
-            FileType.STR.deserialize(
-                rom.getFileByName(f"MESSAGE/{lang.filename}"),
-                string_encoding=static_data.string_encoding,
-            ),
+        yield lang, get_lang_string_file(rom, static_data, lang)
+
+
+def get_lang_string_file(
+    rom: NintendoDSRom, static_data: Pmd2Data, lang: Pmd2Language
+) -> Str:
+    if _str_file_cache.get(lang) is None:
+        _str_file_cache[lang] = FileType.STR.deserialize(
+            rom.getFileByName(f"MESSAGE/{lang.filename}"),
+            string_encoding=static_data.string_encoding,
         )
+    return _str_file_cache[lang]
 
 
 def clone_missing_portraits(kao, index: int, *, force=False):
@@ -605,6 +615,12 @@ def get_allowed_move_ids(
     return lst
 
 
+def get_pokemon_name(rom: NintendoDSRom, static_data: Pmd2Data, md_id: int, lang: Pmd2Language):
+    lang_str = get_lang_string_file(rom, static_data, lang)
+    name_region_begin = static_data.string_index_data.string_blocks["Pokemon Names"].begin
+    return lang_str.strings[name_region_begin + (md_id % 600)]
+
+
 def replace_strings(original: str, replacement_map: dict[str, str]):
     """Replaces all strings from the replacement map in original and returns the new string"""
     string = original
@@ -647,7 +663,6 @@ def replace_text_script(
                     replace_strings(string, replace_map)
                     for string in script.strings[lang.name.lower()]
                 ]
-
 
 _ssb_file_cache: dict[str, Ssb] = {}
 

--- a/skytemple_randomizer/randomizer/util/util.py
+++ b/skytemple_randomizer/randomizer/util/util.py
@@ -615,9 +615,13 @@ def get_allowed_move_ids(
     return lst
 
 
-def get_pokemon_name(rom: NintendoDSRom, static_data: Pmd2Data, md_id: int, lang: Pmd2Language):
+def get_pokemon_name(
+    rom: NintendoDSRom, static_data: Pmd2Data, md_id: int, lang: Pmd2Language
+):
     lang_str = get_lang_string_file(rom, static_data, lang)
-    name_region_begin = static_data.string_index_data.string_blocks["Pokemon Names"].begin
+    name_region_begin = static_data.string_index_data.string_blocks[
+        "Pokemon Names"
+    ].begin
     return lang_str.strings[name_region_begin + (md_id % 600)]
 
 
@@ -663,6 +667,7 @@ def replace_text_script(
                     replace_strings(string, replace_map)
                     for string in script.strings[lang.name.lower()]
                 ]
+
 
 _ssb_file_cache: dict[str, Ssb] = {}
 

--- a/skytemple_randomizer/randomizer_thread.py
+++ b/skytemple_randomizer/randomizer_thread.py
@@ -59,7 +59,7 @@ from skytemple_randomizer.randomizer.special_pc import SpecialPcRandomizer
 from skytemple_randomizer.randomizer.starter import StarterRandomizer
 from skytemple_randomizer.randomizer.text_main import TextMainRandomizer
 from skytemple_randomizer.randomizer.text_script import TextScriptRandomizer
-from skytemple_randomizer.randomizer.util.util import save_scripts, clear_script_cache
+from skytemple_randomizer.randomizer.util.util import save_scripts, clear_script_cache, clear_strings_cache
 from skytemple_randomizer.status import Status
 
 
@@ -135,6 +135,7 @@ class RandomizerThread(Thread):
     def run(self):
         logger.info("Randomizer thread started.")
         clear_script_cache()
+        clear_strings_cache()
         self.thread_id = threading.get_ident()
         try:
             for randomizer in self.randomizers:

--- a/skytemple_randomizer/randomizer_thread.py
+++ b/skytemple_randomizer/randomizer_thread.py
@@ -59,7 +59,11 @@ from skytemple_randomizer.randomizer.special_pc import SpecialPcRandomizer
 from skytemple_randomizer.randomizer.starter import StarterRandomizer
 from skytemple_randomizer.randomizer.text_main import TextMainRandomizer
 from skytemple_randomizer.randomizer.text_script import TextScriptRandomizer
-from skytemple_randomizer.randomizer.util.util import save_scripts, clear_script_cache, clear_strings_cache
+from skytemple_randomizer.randomizer.util.util import (
+    save_scripts,
+    clear_script_cache,
+    clear_strings_cache,
+)
 from skytemple_randomizer.status import Status
 
 


### PR DESCRIPTION
This PR enhances the NPC randomisation in the following ways:

- Use the new string block regions defined as part of https://github.com/SkyTemple/skytemple-files/pull/495 to ensure more string regions are being covered via smart replace
- Implement string replacement for bazaar Pokemons, as previously texts pertaining to Kirlia and Shedinja weren't being replaced due to them not being actors
- Add a simple dict cache for `Str` objects based on `Pmd2Language`