### PR TITLE
Apply RemoveBodySizeCheck patch

### DIFF
--- a/skytemple_randomizer/randomizer/patch_applier.py
+++ b/skytemple_randomizer/randomizer/patch_applier.py
@@ -87,6 +87,9 @@ class PatchApplier(AbstractRandomizer):
         if not patcher.is_applied("NoWeatherStop"):
             patcher.apply("NoWeatherStop")
 
+        if not patcher.is_applied("RemoveBodySizeCheck"):
+            patcher.apply("RemoveBodySizeCheck")
+
         if self.config["quiz"]["mode"] != QuizMode.TEST:
             status.step(_("Apply personality test patches..."))
             if not patcher.is_applied("ChooseStarter"):


### PR DESCRIPTION
Applies the RemoveBodySizeCheck patch. Requires https://github.com/SkyTemple/skytemple-files/pull/500.
Useful for runs where both the player and partner are large pokémon, since normally the game doesn't let the player into dungeons if that's the case, softlocking them.