### PR TITLE
Make sure the wheel built contains proper UI files

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install gobject-introspection
-      run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev
+      run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev gir1.2-gtk-4.0 gir1.2-adw-1
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -77,6 +77,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install gobject-introspection
+        run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev gir1.2-gtk-4.0 gir1.2-adw-1
       - name: Rewrite version for dev if not tag
         if: "!startsWith(github.ref, 'refs/tags/')"
         run: |
@@ -84,8 +86,6 @@ jobs:
       - name: Note version
         run: |
           echo "PACKAGE_VERSION=$(tomlq '.project.version' pyproject.toml -r)" >> $GITHUB_ENV
-      - name: Run make
-        run: make
       - name: Build Python wheels
         run: |
           python3 -m pip install --upgrade build
@@ -397,8 +397,6 @@ jobs:
           python -c 'import gi; gi.require_version("Gtk", "4.0"); gi.require_version("Adw", "1"); from gi.repository import GObject, Gio, GLib, Gtk, Gdk, Adw'
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           
-          # Convert Blueprint files
-          .\build-blp-to-ui.ps1
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
           cd installer
@@ -456,18 +454,12 @@ jobs:
         run: |
           . .venv/bin/activate
           pip3 install "pygobject>=3.44.0"
-      - name: Convert Blueprint files
-        run: |
-          . .venv/bin/activate
-          ./build-blp-to-ui.sh
       - name: Install and package
         run: |
           . .venv/bin/activate
           # Install other dependencies and SkyTemple Randomizer itself
           pip3 install skytemple-rust 'pyinstaller~=6.0'
           pip3 install -r requirements-frozen.txt
-          # Generate MO localization files
-          installer/generate-mo.sh
           pip3 install '.[gtk]'
           if [ -n "$IS_DEV_BUILD" ]; then
             installer/install-skytemple-components-from-git.sh
@@ -533,18 +525,12 @@ jobs:
         run: |
           . .venv/bin/activate
           pip3 install "pygobject>=3.44.0"
-      - name: Convert Blueprint files
-        run: |
-          . .venv/bin/activate
-          ./build-blp-to-ui.sh
       - name: Install and package
         run: |
           . .venv/bin/activate
           # Install other dependencies and SkyTemple Randomizer itself
           pip3 install skytemple-rust 'pyinstaller~=6.0'
           pip3 install -r requirements-frozen.txt
-          # Generate MO localization files
-          installer/generate-mo.sh
           pip3 install '.[gtk]'
           if [ -n "$IS_DEV_BUILD" ]; then
             installer/install-skytemple-components-from-git.sh

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -67,7 +67,7 @@ jobs:
         run: ruff format --check skytemple_randomizer
         
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Build the Python wheel
     steps:
       # For tags we assume the version in pyproject.toml is correct!
@@ -86,7 +86,7 @@ jobs:
           echo "PACKAGE_VERSION=$(tomlq '.project.version' pyproject.toml -r)" >> $GITHUB_ENV
       - name: Build Python wheels
         run: |
-          python3 -m pip install --upgrade build
+          python3 -m pip install --break-system-packages --upgrade build
           python3 -m build
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -37,8 +37,8 @@ jobs:
     name: Linting
     steps:
     - uses: actions/checkout@v4
-    - name: Install gobject-introspection
-      run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev gir1.2-gtk-4.0 gir1.2-adw-1
+    - name: Install gobject-introspection and other build deps
+      run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev gir1.2-gtk-4.0 gir1.2-adw-1 pkg-config libcairo2-dev gettext make
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -75,8 +75,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install gobject-introspection
-        run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev gir1.2-gtk-4.0 gir1.2-adw-1
+      - name: Install gobject-introspection and other build deps
+        run: sudo apt-get install -y gobject-introspection libgirepository1.0-dev gir1.2-gtk-4.0 gir1.2-adw-1 pkg-config libcairo2-dev gettext make
       - name: Rewrite version for dev if not tag
         if: "!startsWith(github.ref, 'refs/tags/')"
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -69,8 +69,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build the Python wheel
-    container:
-      image: ghcr.io/skytemple/gtk4-build-image:1
     steps:
       # For tags we assume the version in pyproject.toml is correct!
       - name: Checkout

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,4 @@ graft skytemple_randomizer/data
 include skytemple_randomizer/py.typed
 graft _custom_build
 graft blueprint-compiler
-include build-blp-to-ui.ps1
-include build-blp-to-ui.sh
+include Makefile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
-include skytemple_randomizer/frontend/gtk/widgets/*.ui
+include skytemple_randomizer/frontend/gtk/widgets/*.blp
 include skytemple_randomizer/frontend/gtk/*.css
 graft skytemple_randomizer/data
 include skytemple_randomizer/py.typed
+graft _custom_build
+graft blueprint-compiler
+include build-blp-to-ui.ps1
+include build-blp-to-ui.sh

--- a/_custom_build/_build.ps1
+++ b/_custom_build/_build.ps1
@@ -1,3 +1,5 @@
+# Windows build script.
+# This is normally run from backend.py and assumes the working directory to be the source distribution root directory.
 $ErrorActionPreference = "Stop"
 # Convert the Blueprint UI files to XML.
 # This requires the blueprint-compiler submodule to be checked out.

--- a/_custom_build/_build.ps1
+++ b/_custom_build/_build.ps1
@@ -3,3 +3,10 @@ $ErrorActionPreference = "Stop"
 # This requires the blueprint-compiler submodule to be checked out.
 python .\blueprint-compiler\blueprint-compiler.py batch-compile skytemple_randomizer\frontend\gtk\widgets skytemple_randomizer\frontend\gtk\widgets (Resolve-Path skytemple_randomizer\frontend\gtk\widgets\*.blp)
 if ($LASTEXITCODE) { exit $LASTEXITCODE }
+# Build MO message files
+Get-ChildItem -Recurse -Path skytemple_randomizer\data\locale\ -Filter '*.po' | ForEach-Object {
+  $poFile = $_.FullName;
+  $moFile = [System.IO.Path]::ChangeExtension($poFile, ".mo");
+  msgfmt -o $moFile $poFile
+}
+if ($LASTEXITCODE) { exit $LASTEXITCODE }

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -8,11 +8,11 @@ from setuptools.build_meta import *  # noqa: F403
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """
-    Build the wheel, but before: build all UI XML files.
+    Build the wheel, but before: Build all UI files and MO files
     """
-    print("Building Blueprint files...")
+    print("Building Blueprint files and locale message files...")
     if platform.system() == "Windows":
-        subprocess.run(["powershell.exe", r".\build-blp-to-ui.ps1"], check=True)
+        subprocess.run(["powershell.exe", r".\_custom_build\_build.ps1"], check=True)
     else:
-        subprocess.run(["./build-blp-to-ui.sh"], check=True)
+        subprocess.run(["make"], check=True)
     return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,18 @@
+# mypy: ignore-errors
+import platform
+import subprocess
+
+from setuptools import build_meta as _orig
+from setuptools.build_meta import *  # noqa: F403
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    """
+    Build the wheel, but before: build all UI XML files.
+    """
+    print("Building Blueprint files...")
+    if platform.system() == "Windows":
+        subprocess.run(["powershell.exe", r".\build-blp-to-ui.ps1"], check=True)
+    else:
+        subprocess.run(["./build-blp-to-ui.sh"], check=True)
+    return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/build-blp-to-ui.sh
+++ b/build-blp-to-ui.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# Convert the Blueprint UI files to XML.
-# This requires the blueprint-compiler submodule to be checked out.
-set -xe
-./blueprint-compiler/blueprint-compiler.py \
-  batch-compile \
-  skytemple_randomizer/frontend/gtk/widgets \
-  skytemple_randomizer/frontend/gtk/widgets \
-  skytemple_randomizer/frontend/gtk/widgets/*.blp

--- a/installer/build-windows.ps1
+++ b/installer/build-windows.ps1
@@ -24,11 +24,16 @@ pip install setuptools wheel 'pyinstaller~=6.0'
 # Install certifi for cert handling
 pip3 install -U certifi
 
+# Just to make sure: force reinstall the proper PyGObject versions
+pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl)
+pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl)
+
 # install SkyTemple Randomizer
 pip3 install -r ../requirements-frozen.txt
 # No build isolation to re-use system PyGObject.
 pip3 install --no-build-isolation '..[gtk]'
-# pip likes to troll us. Force reinstall the proper PyGObject versions
+
+# Just to make sure: force reinstall the proper PyGObject versions
 pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl)
 pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl)
 

--- a/installer/build-windows.ps1
+++ b/installer/build-windows.ps1
@@ -24,9 +24,6 @@ pip install setuptools wheel 'pyinstaller~=6.0'
 # Install certifi for cert handling
 pip3 install -U certifi
 
-# Generate MO localization files
-bash .\generate-mo.sh
-
 # install SkyTemple Randomizer
 pip3 install -r ../requirements-frozen.txt
 pip3 install '..[gtk]'

--- a/installer/build-windows.ps1
+++ b/installer/build-windows.ps1
@@ -26,7 +26,8 @@ pip3 install -U certifi
 
 # install SkyTemple Randomizer
 pip3 install -r ../requirements-frozen.txt
-pip3 install '..[gtk]'
+# No build isolation to re-use system PyGObject.
+pip3 install --no-build-isolation '..[gtk]'
 # pip likes to troll us. Force reinstall the proper PyGObject versions
 pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pygobject\dist\PyGObject*.whl)
 pip install --force-reinstall (Resolve-Path C:\gtk-build\build\x64\release\pycairo\dist\pycairo*.whl)

--- a/installer/generate-mo.sh
+++ b/installer/generate-mo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-find $SCRIPT_DIR/../skytemple_randomizer/data/locale -iname "*.po" -exec sh -c 'msgfmt -o "${1%.po}.mo" "$1"' sh {} \;

--- a/installer/linux-flatpak/org.skytemple.Randomizer.yml.jinja
+++ b/installer/linux-flatpak/org.skytemple.Randomizer.yml.jinja
@@ -73,7 +73,6 @@ modules:
   - name: randomizer
     buildsystem: simple
     build-commands:
-      - make
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}/links" --prefix=${FLATPAK_DEST} --no-deps '.[gtk]'
       # Icons
       - install -Dm644 skytemple_randomizer/data/icons/hicolor/16x16/apps/skytemple_randomizer.png /app/share/icons/hicolor/16x16/apps/org.skytemple.Randomizer.png

--- a/installer/linux-flatpak/org.skytemple.Randomizer.yml.jinja
+++ b/installer/linux-flatpak/org.skytemple.Randomizer.yml.jinja
@@ -73,7 +73,8 @@ modules:
   - name: randomizer
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}/links" --prefix=${FLATPAK_DEST} --no-deps '.[gtk]'
+      # No build isolation so we don't have to rebuild PyGObject. It's only needed for building the UI files from Blueprint files.
+      - pip3 install --verbose --no-build-isolation --exists-action=i --no-index --find-links="file://${PWD}/links" --prefix=${FLATPAK_DEST} --no-deps '.[gtk]'
       # Icons
       - install -Dm644 skytemple_randomizer/data/icons/hicolor/16x16/apps/skytemple_randomizer.png /app/share/icons/hicolor/16x16/apps/org.skytemple.Randomizer.png
       - install -Dm644 skytemple_randomizer/data/icons/hicolor/32x32/apps/skytemple_randomizer.png /app/share/icons/hicolor/32x32/apps/org.skytemple.Randomizer.png
@@ -91,5 +92,3 @@ modules:
       - {{ skytemple_randomizer_ref }}
       - type: file
         path: assets/run.sh
-      {{ "setuptools"|pip_add_group("links") }}
-      {{ "flit"|pip_add_group("links") }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "pygobject"]
 build-backend = "backend"
 backend-path = ["_custom_build"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+build-backend = "backend"
+backend-path = ["_custom_build"]
 
 [project]
 name = "skytemple-randomizer"
@@ -54,6 +55,9 @@ skytemple_randomizer = "skytemple_randomizer.main:main"
 [tool.setuptools]
 packages.find.include = ["skytemple_randomizer", "skytemple_randomizer.*"]
 packages.find.exclude = ["installer", "blueprint-compiler"]
+
+[tool.setuptools.package-data]
+"*" = ["*.ui"]  # Make sure that UI files also get added to the wheel but NOT sdist.
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Previously it was not possible to install SkyTemple Randomizer from just PyPI, because the source dists and wheels only contained the Blueprint (*.blp) source files.

Now there is a custom build backend which builds the blp -> ui files during the wheel build. This means that:
- The source wheel can now be built into a proper working wheel and the GTK frontend works
- The wheel on PyPI now actually works when installed from PyPI via pip (the GTK frontend works)

The same applies for the localization files (po -> mo).

This adds a new implicit dependency on PowerShell under Windows, `make` under Linux/macOS and `msgfmt` from gettext for all.